### PR TITLE
refactor(server): remove deprecated build counter API

### DIFF
--- a/server/api/urls.py
+++ b/server/api/urls.py
@@ -3,7 +3,6 @@ from rest_framework.schemas import get_schema_view
 
 from config import settings
 from .views import (
-    V1DownloadBuildCounter,
     V1GeneralBuildLatest,
     V1GeneralDeviceAll,
     V1GeneralMaintainerAll,
@@ -56,11 +55,6 @@ urlpatterns = [
         "latest/download/count/all/",
         v1_download_count_all,
         name="latest_download_count_all",
-    ),
-    path(
-        "v1/download/build/counter/",
-        V1DownloadBuildCounter.as_view(),
-        name="v1_download_build_counter",
     ),
     path(
         "v2/download/build/counter/",

--- a/server/api/views/__init__.py
+++ b/server/api/views/__init__.py
@@ -13,7 +13,6 @@ from .shippy import (
     v1_system_info,
 )
 from .statistics import (
-    V1DownloadBuildCounter,
     V2DownloadBuildCounter,
     v1_download_count_all,
     v1_download_count_day,
@@ -33,7 +32,6 @@ __all__ = [
     "v1_maintainers_token_check",
     "v1_maintainers_upload_filename_regex_pattern",
     "v1_system_info",
-    "V1DownloadBuildCounter",
     "V2DownloadBuildCounter",
     "v1_download_count_day",
     "v1_download_count_week",

--- a/server/api/views/statistics.py
+++ b/server/api/views/statistics.py
@@ -45,50 +45,46 @@ class V2DownloadBuildCounter(APIView):
                 status=HTTP_400_BAD_REQUEST,
             )
 
-        return create_statistics_from_request(ip, request)
-
-
-def create_statistics_from_request(ip, request):
-    file_name = request.data.get("file_name")
-    if file_name:
-        try:
-            build = Build.objects.get(file_name=file_name)
-            Statistics.objects.create(build=build, ip=ip)
-            return Response(
-                {"message": "The request was successful!"}, status=HTTP_200_OK
-            )
-        except Build.DoesNotExist:
-            return Response(
-                {
-                    "error": "invalid_build_name",
-                    "message": "A build with that file name does not exist!",
-                },
-                status=HTTP_404_NOT_FOUND,
-            )
-    build_id = request.data.get("build_id")
-    if build_id:
-        try:
-            build = Build.objects.get(pk=int(build_id))
-            Statistics.objects.create(build=build, ip=ip)
-            return Response(
-                {"message": "The request was successful!"}, status=HTTP_200_OK
-            )
-        except Build.DoesNotExist:
-            return Response(
-                {
-                    "error": "invalid_build_id",
-                    "message": "A build with that ID does not exist!",
-                },
-                status=HTTP_404_NOT_FOUND,
-            )
-    return Response(
-        {
-            "error": "missing_parameters",
-            "message": "No parameters specified. Specify a file_name parameter or "
-            "a build_id parameter.",
-        },
-        status=HTTP_400_BAD_REQUEST,
-    )
+        file_name = request.data.get("file_name")
+        if file_name:
+            try:
+                build = Build.objects.get(file_name=file_name)
+                Statistics.objects.create(build=build, ip=ip)
+                return Response(
+                    {"message": "The request was successful!"}, status=HTTP_200_OK
+                )
+            except Build.DoesNotExist:
+                return Response(
+                    {
+                        "error": "invalid_build_name",
+                        "message": "A build with that file name does not exist!",
+                    },
+                    status=HTTP_404_NOT_FOUND,
+                )
+        build_id = request.data.get("build_id")
+        if build_id:
+            try:
+                build = Build.objects.get(pk=int(build_id))
+                Statistics.objects.create(build=build, ip=ip)
+                return Response(
+                    {"message": "The request was successful!"}, status=HTTP_200_OK
+                )
+            except Build.DoesNotExist:
+                return Response(
+                    {
+                        "error": "invalid_build_id",
+                        "message": "A build with that ID does not exist!",
+                    },
+                    status=HTTP_404_NOT_FOUND,
+                )
+        return Response(
+            {
+                "error": "missing_build_information",
+                "message": "No build information specified. Specify a file_name "
+                "parameter or a build_id parameter.",
+            },
+            status=HTTP_400_BAD_REQUEST,
+        )
 
 
 @csrf_exempt

--- a/server/api/views/statistics.py
+++ b/server/api/views/statistics.py
@@ -11,30 +11,6 @@ from rest_framework.views import APIView
 from core.models import Build, Statistics
 
 
-# WARNING: This endpoint is deprecated!
-class V1DownloadBuildCounter(APIView):
-    """
-    Increments the download count for a given build
-    """
-
-    permission_classes = [AllowAny]
-
-    # noinspection PyMethodMayBeStatic
-    def post(self, request):
-        # Try getting IP
-        ip = request.META.get("REMOTE_ADDR")
-        if ip is None:
-            return Response(
-                {
-                    "error": "invalid_ip",
-                    "message": "Your IP address is invalid!",
-                },
-                status=HTTP_400_BAD_REQUEST,
-            )
-
-        return create_statistics_from_request(ip, request)
-
-
 class V2DownloadBuildCounter(APIView):
     """
     Increments the download count for a given build


### PR DESCRIPTION
None of the clients were using it anyway, so remove it with the next release