### PR TITLE
Add "archived" builds functionality

### DIFF
--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -283,6 +283,11 @@ CONSTANCE_CONFIG = {
         "supported. Specify multiple versions on each line.",
         str,
     ),
+    "SHIPPER_BUILD_ARCHIVE_DAYS": (
+        90,
+        "Builds that are 'archived' in the system after this many number of days. "
+        "Archived builds are not mirrored to any mirror servers.",
+    ),
 }
 CONSTANCE_CONFIG_FIELDSETS = {
     "Downloads page": (
@@ -297,6 +302,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         "SHIPPER_FILE_NAME_FORMAT",
         "SHIPPER_ALLOWED_VERSIONS_TO_UPLOAD",
     ),
+    "Maintenance": ("SHIPPER_BUILD_ARCHIVE_DAYS",),
 }
 
 # Django Crispy Forms

--- a/server/core/models.py
+++ b/server/core/models.py
@@ -327,6 +327,14 @@ class Build(models.Model):
 
         return has_mirror
 
+    @admin.display(
+        description="Archived",
+        boolean=True,
+    )
+    def is_archived(self):
+        age = date.today() - self.build_date
+        return age > config.SHIPPER_BUILD_ARCHIVE_DAYS
+
     def __str__(self):
         return self.file_name
 


### PR DESCRIPTION
This will allow us to lessen the storage burden on our mirror servers by keeping "archived" builds from being mirrored (builds that are older than N amount of days).