### PR TITLE
fix(server): raise explicit build mirror exception on network errors

### DIFF
--- a/server/core/tasks.py
+++ b/server/core/tasks.py
@@ -152,11 +152,20 @@ def upload_build_to_mirror(self, build_id, build, mirror):
         temp_target_file_name = f"{target_file_name}.part"
 
         logger.info("Starting upload...")
-        sftp.put(
-            localpath=os.path.join(settings.MEDIA_ROOT, build.zip_file.name),
-            remotepath=temp_target_file_name,
-            callback=update_progress,
-        )
+        try:
+            sftp.put(
+                localpath=os.path.join(settings.MEDIA_ROOT, build.zip_file.name),
+                remotepath=temp_target_file_name,
+                callback=update_progress,
+            )
+        except EOFError:
+            raise BuildMirrorException(
+                {
+                    "message": "A network error occured while uploading the "
+                    "build file.",
+                    "exception_message": "EOFError",
+                }
+            )
 
         try:
             sftp.stat(target_file_name)


### PR DESCRIPTION
We've configured Sentry to ignore these errors, so map them explicitly.


<!--
Thank you for submitting a pull request! Please take some time to read through
the sections and make sure you've completed all items.
-->

## Description
<!-- A brief description of the changes made by your pull request -->

Fixes the issue where EOFErrors raise a bug report on Sentry

## Type of change

- [ ] Dependency update
- [x] Bugfix
- [ ] New feature
- [ ] (!) Breaking change

<!--
Note: the pull request won't be penalized for checking breaking change, this is
just for us to track and give more attention to the particular pull request.
-->

## Checklist

<!--
Note: if a checklist item isn't complete, just submit the pull request. You can
add more commits to rectify and complete an item later by pushing those commits
to the branch associated with this pull request. If you need help, please choose
"Allow edits by maintainers" so that we can push commits to your branch for you.
-->

I've completed...

- [x] My pull request does not have any migration files.

Migration files will be created before release so that there are no conflicts.
If you have added migration files, please remove them with another commit. We
will recreate them for you by basing off of the `master` branch.


## Additional Information

<!-- If not applicable, please remove this! -->

- (if applicable) this closes issue: Fixes #716
