### PR TITLE
fix(shippy): do not use live display for temporary messages

### DIFF
--- a/shippy/shippy/client.py
+++ b/shippy/shippy/client.py
@@ -80,19 +80,17 @@ def log_debug_request_response(r):
 
 
 def wait_rate_limit(seconds):
-    with console.status(RATE_LIMIT_WAIT_STATUS_MSG.format(seconds)) as status:
-        while seconds:
-            time.sleep(1)
-            seconds -= 1
-            status.update(status=RATE_LIMIT_WAIT_STATUS_MSG.format(seconds))
+    while seconds:
+        print(RATE_LIMIT_WAIT_STATUS_MSG.format(seconds))
+        time.sleep(1)
+        seconds -= 1
 
 
 def wait_temporary_error(seconds):
-    with console.status(SERVER_ERROR_WAIT_STATUS_MSG.format(seconds)) as status:
-        while seconds:
-            time.sleep(1)
-            seconds -= 1
-            status.update(status=SERVER_ERROR_WAIT_STATUS_MSG.format(seconds))
+    while seconds:
+        print(SERVER_ERROR_WAIT_STATUS_MSG.format(seconds))
+        time.sleep(1)
+        seconds -= 1
 
 
 class Client:


### PR DESCRIPTION
Rate limiting and temporary error messages should be printed directly to stdout, since there will usually be a live display active showing the progress of the upload. The rich library does not support two live displays at once, so print them out instead.

<!--
Thank you for submitting a pull request! Please take some time to read through
the sections and make sure you've completed all items.
-->

## Description
<!-- A brief description of the changes made by your pull request -->

Fixes shippy crashing upon encountering a temporary error or rate limit

## Type of change

- [ ] Dependency update
- [x] Bugfix
- [ ] New feature
- [ ] (!) Breaking change

<!--
Note: the pull request won't be penalized for checking breaking change, this is
just for us to track and give more attention to the particular pull request.
-->

## Checklist

<!--
Note: if a checklist item isn't complete, just submit the pull request. You can
add more commits to rectify and complete an item later by pushing those commits
to the branch associated with this pull request. If you need help, please choose
"Allow edits by maintainers" so that we can push commits to your branch for you.
-->

I've completed...

- [x] My pull request does not have any migration files.

Migration files will be created before release so that there are no conflicts.
If you have added migration files, please remove them with another commit. We
will recreate them for you by basing off of the `master` branch.


## Additional Information

<!-- If not applicable, please remove this! -->

- (if applicable) this closes issue: Fixes #690
