### PR TITLE
fix(shippy): use regex pattern for matching build slugs

### DIFF
--- a/shippy/.idea/misc.xml
+++ b/shippy/.idea/misc.xml
@@ -5,5 +5,5 @@
     <option name="enabledOnSave" value="true" />
     <option name="sdkName" value="Python 3.12 (shippy)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (shippy)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (shippy)" project-jdk-type="Python SDK" />
 </project>

--- a/shippy/.idea/shippy.iml
+++ b/shippy/.idea/shippy.iml
@@ -5,7 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.13 (shippy)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/shippy/shippy/__main__.py
+++ b/shippy/shippy/__main__.py
@@ -1,7 +1,6 @@
 import argparse
 import re
 import glob
-import os.path
 import signal
 import sys
 from json import JSONDecodeError
@@ -298,18 +297,16 @@ def check_build(client, filename):
             return False
         print_success(f"Checksum {has_checksum_file_type.upper()} hash matches!")
 
-    build_slug, _ = os.path.splitext(filename)
-    _, _, _, build_type, build_variant, _ = build_slug.split("-")
+    matches = re.search(client.get_regex_pattern(), filename)
 
-    # Check build type
-    if build_type != "OFFICIAL":
-        print_error(msg="This build is not official. ", newline=False, exit_after=False)
+    if not matches:
+        print_error(msg="This build does not match any file name patterns. ", newline=False, exit_after=False)
         return False
-    else:
-        print_success("Build type is official!")
+
+    variant = matches.group("variant")
 
     # Check build variant
-    if build_variant not in client.get_shippy_upload_variants():
+    if variant not in client.get_shippy_upload_variants():
         print_error(
             msg="This build has an unknown variant. ",
             newline=False,
@@ -317,7 +314,7 @@ def check_build(client, filename):
         )
         return False
     else:
-        print_success(f"Build variant {build_variant} is supported!")
+        print_success(f"Build variant {variant} is supported!")
 
     print_success(f"Validation of build {filename} complete. No problems found.")
     return True


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please take some time to read through
the sections and make sure you've completed all items.
-->

## Description
<!-- A brief description of the changes made by your pull request -->

This commit uses the regex pattern fetched from the server to validate build slugs. This means that shippy is now compatible with different file name regex patterns configured by the server.

This removes some checks like the build type (ex. `OFFICIAL`) because it can be set through the file name regex pattern.


## Type of change

- [ ] Dependency update
- [x] Bugfix
- [ ] New feature
- [ ] (!) Breaking change

<!--
Note: the pull request won't be penalized for checking breaking change, this is
just for us to track and give more attention to the particular pull request.
-->

## Checklist

<!--
Note: if a checklist item isn't complete, just submit the pull request. You can
add more commits to rectify and complete an item later by pushing those commits
to the branch associated with this pull request. If you need help, please choose
"Allow edits by maintainers" so that we can push commits to your branch for you.
-->

I've completed...

- [x] My pull request does not have any migration files.

Migration files will be created before release so that there are no conflicts.
If you have added migration files, please remove them with another commit. We
will recreate them for you by basing off of the `master` branch.


## Additional Information

<!-- If not applicable, please remove this! -->

- (if applicable) this closes issue: Fixes #689
