### PR TITLE
fix(server): explicitly check for x86_type in filename parts

### DIFF
--- a/server/api/handler.py
+++ b/server/api/handler.py
@@ -44,6 +44,15 @@ def handle_chunked_build(device, chunked_file):
     # If x86, check for x86 type
     if filename_parts["codename"] in X86_DEVICE_CODENAMES:
         x86_type_codenames = [x.codename for x in X86Type.objects.all()]
+        if "x86_type" not in filename_parts:
+            raise UploadException(
+                {
+                    "error": "missing_x86_type",
+                    "message": "The x86 type is missing from the build's file name, "
+                    "even though the build is an x86 build.",
+                }
+            )
+
         if filename_parts["x86_type"] not in x86_type_codenames:
             raise UploadException(
                 {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please take some time to read through
the sections and make sure you've completed all items.
-->

## Description
<!-- A brief description of the changes made by your pull request -->

Fixes crash in server code when handling x86 build files that do not conform to naming scheme

## Type of change

- [ ] Dependency update
- [x] Bugfix
- [ ] New feature
- [ ] (!) Breaking change

<!--
Note: the pull request won't be penalized for checking breaking change, this is
just for us to track and give more attention to the particular pull request.
-->

## Checklist

<!--
Note: if a checklist item isn't complete, just submit the pull request. You can
add more commits to rectify and complete an item later by pushing those commits
to the branch associated with this pull request. If you need help, please choose
"Allow edits by maintainers" so that we can push commits to your branch for you.
-->

I've completed...

- [x] My pull request does not have any migration files.

Migration files will be created before release so that there are no conflicts.
If you have added migration files, please remove them with another commit. We
will recreate them for you by basing off of the `master` branch.


## Additional Information

<!-- If not applicable, please remove this! -->

- (if applicable) this closes issue: Fixes #747
